### PR TITLE
Feat(#22): github action secret을 env 파일에 적용

### DIFF
--- a/.github/workflows/devcd.yml
+++ b/.github/workflows/devcd.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: ["main", "develop", "feature/12-test-cd"]
+    branches: ["main", "develop", "feature/22"]
 
   workflow_dispatch:
 
@@ -19,6 +19,16 @@ jobs:
         with:
           java-version: "17"
           distribution: "zulu"
+      - uses: oNaiPs/secrets-to-env-action@v1
+        with:
+          secrets: ${{ toJSON(secrets) }}
+          include: DEV*
+      - run: echo DEV_VARIABLES=$DEV_SECRET" >> "$GITHUB_ENV"
+
+      - name: save into .env.properties
+          - run : | 
+                jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' <<< "$DEB_VARIALBES" > ./config/env.properties
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 

--- a/.github/workflows/devcd.yml
+++ b/.github/workflows/devcd.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: ["main", "develop", "feature/22"]
+    branches: ["main", "develop", "test/22"]
 
   workflow_dispatch:
 


### PR DESCRIPTION
# 개발사항

- action을 활용해서 env 파일에 secret값들을 집어넣는 기능

## 세부사항
- 테스트를 위해 현재 브랜치를 허용한다
### example-1 기능 추가

- 세부 설명

### example-2 기능 추가

- 세부 설명

## 추가사항

Closes #22