### PR TITLE
hotfix(#57): 회원 가입 시 유저 닉네임이 DB에 저장되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/movte/slate/domain/user/application/service/UserService.java
+++ b/src/main/java/com/movte/slate/domain/user/application/service/UserService.java
@@ -89,6 +89,7 @@ public class UserService {
                 .userState(UserState.APPROVED)
                 .oauthProvider(provider)
                 .profileImageUrl(request.getProfileImageUrl())
+                .nickname(idToken.getNickname())
                 .build();
         user = userRepository.save(user);
         String accessToken = jwtTokenIssuer.createAccessToken(user);


### PR DESCRIPTION
hotfix(#57): 회원 가입 시 유저 닉네임이 DB에 저장되지 않는 문제 해결

- User 객체 생성 시, nickname 초기화 안 했음.
- 해당 문제 해결