### PR TITLE
Feat(#90): 코스 API 구현

### DIFF
--- a/src/main/java/com/movte/slate/domain/course/api/CourseApi.java
+++ b/src/main/java/com/movte/slate/domain/course/api/CourseApi.java
@@ -1,0 +1,32 @@
+package com.movte.slate.domain.course.api;
+
+
+import com.movte.slate.domain.course.application.CourseSearchUseCase;
+import com.movte.slate.domain.course.dto.CourseDetailResponse;
+import com.movte.slate.domain.course.dto.CourseListResponse;
+import com.movte.slate.global.response.ResponseFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class CourseApi {
+
+    private final CourseSearchUseCase courseSearchUseCase;
+
+    @GetMapping("/course/all")
+    public ResponseEntity<?> getList(){
+        List<CourseListResponse> result = courseSearchUseCase.getList();
+        return ResponseFactory.success(result);
+    }
+
+    @GetMapping("/course/{id}")
+    public ResponseEntity<?> getOne(@PathVariable("id") Long id){
+        CourseDetailResponse result = courseSearchUseCase.getDetail(id);
+        return ResponseFactory.success(result);
+    }
+}

--- a/src/main/java/com/movte/slate/domain/course/application/CourseSearchUseCase.java
+++ b/src/main/java/com/movte/slate/domain/course/application/CourseSearchUseCase.java
@@ -1,0 +1,34 @@
+package com.movte.slate.domain.course.application;
+
+
+import com.movte.slate.domain.course.domain.Course;
+import com.movte.slate.domain.course.dto.CourseDetailResponse;
+import com.movte.slate.domain.course.dto.CourseListResponse;
+import com.movte.slate.domain.course.repository.CourseRepository;
+import com.movte.slate.global.exception.NotFoundException;
+import com.movte.slate.global.exception.NotFoundExceptionCode;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CourseSearchUseCase {
+
+    private final CourseRepository courseRepository;
+
+
+    public List<CourseListResponse> getList() {
+        List<Course> courses = courseRepository.findAll();
+        return courses.stream().map(CourseListResponse::from).toList();
+    }
+
+    public CourseDetailResponse getDetail(Long courseId) {
+        Course course = courseRepository.selectCourseByIdWithImages(courseId)
+            .orElseThrow(() -> new NotFoundException(NotFoundExceptionCode.NOT_FOUND_COURSE));
+        return CourseDetailResponse.from(course);
+    }
+
+}

--- a/src/main/java/com/movte/slate/domain/course/domain/Course.java
+++ b/src/main/java/com/movte/slate/domain/course/domain/Course.java
@@ -1,0 +1,45 @@
+package com.movte.slate.domain.course.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "course")
+public class Course {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+    @Column(nullable = false, name = "sub_title")
+    private String subTitle;
+
+    @Column(nullable = false, name = "thumbnail_image_url")
+    private String thumbnailImageUrl;
+
+    @OneToMany(mappedBy = "course", fetch = FetchType.LAZY)
+    private List<CourseImage> courseImages = new ArrayList<>();
+
+    @Builder
+    public Course(Long id, String title, String subTitle) {
+        this.id = id;
+        this.title = title;
+        this.subTitle = subTitle;
+    }
+}

--- a/src/main/java/com/movte/slate/domain/course/domain/CourseImage.java
+++ b/src/main/java/com/movte/slate/domain/course/domain/CourseImage.java
@@ -1,0 +1,44 @@
+package com.movte.slate.domain.course.domain;
+
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "course_image")
+public class CourseImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+
+    @Column(name = "course_order")
+    private Integer courseOrder;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "course_id")
+    private Course course;
+
+    @Builder
+    public CourseImage(String imageUrl, Integer order) {
+        this.imageUrl = imageUrl;
+        this.courseOrder = order;
+    }
+}

--- a/src/main/java/com/movte/slate/domain/course/dto/CourseDetailResponse.java
+++ b/src/main/java/com/movte/slate/domain/course/dto/CourseDetailResponse.java
@@ -1,0 +1,43 @@
+package com.movte.slate.domain.course.dto;
+
+
+import com.movte.slate.domain.course.domain.Course;
+import java.util.Comparator;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CourseDetailResponse {
+
+    private Long courseId;
+    private String title;
+    private String subTitle;
+    private String thumbnailImageUrl;
+    private List<CourseImageResponse> courseImageResponses;
+
+    @Builder
+    public CourseDetailResponse(Long courseId, String title, String subTitle,
+        String thumbnailImageUrl,
+        List<CourseImageResponse> courseImageResponses) {
+        this.courseId = courseId;
+        this.title = title;
+        this.subTitle = subTitle;
+        this.thumbnailImageUrl = thumbnailImageUrl;
+        this.courseImageResponses = courseImageResponses;
+    }
+
+    public static CourseDetailResponse from(Course course) {
+        return CourseDetailResponse.builder()
+            .courseId(course.getId())
+            .title(course.getTitle())
+            .subTitle(course.getSubTitle())
+            .thumbnailImageUrl(course.getThumbnailImageUrl())
+            .courseImageResponses(
+                course.getCourseImages().stream().map(CourseImageResponse::from)
+                    .sorted((Comparator.comparingInt(CourseImageResponse::getOrder))).toList())
+            .build();
+    }
+}

--- a/src/main/java/com/movte/slate/domain/course/dto/CourseImageResponse.java
+++ b/src/main/java/com/movte/slate/domain/course/dto/CourseImageResponse.java
@@ -1,0 +1,23 @@
+package com.movte.slate.domain.course.dto;
+
+
+import com.movte.slate.domain.course.domain.CourseImage;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CourseImageResponse {
+
+    private String imageUrl;
+    private int order;
+
+    public CourseImageResponse(String imageUrl, int order) {
+        this.imageUrl = imageUrl;
+        this.order = order;
+    }
+
+    public static CourseImageResponse from(CourseImage image) {
+        return new CourseImageResponse(image.getImageUrl(), image.getCourseOrder());
+    }
+}

--- a/src/main/java/com/movte/slate/domain/course/dto/CourseListResponse.java
+++ b/src/main/java/com/movte/slate/domain/course/dto/CourseListResponse.java
@@ -1,0 +1,35 @@
+package com.movte.slate.domain.course.dto;
+
+import com.movte.slate.domain.course.domain.Course;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CourseListResponse {
+
+    private Long courseId;
+    private String title;
+    private String subTitle;
+    private String thumbnailImageUrl;
+
+    @Builder
+    private CourseListResponse(Long courseId, String title, String subTitle,
+        String thumbnailImageUrl) {
+        this.courseId = courseId;
+        this.title = title;
+        this.subTitle = subTitle;
+        this.thumbnailImageUrl = thumbnailImageUrl;
+    }
+
+    public static CourseListResponse from(Course course) {
+        return CourseListResponse.builder()
+            .courseId(course.getId())
+            .title(course.getTitle())
+            .subTitle(course.getSubTitle())
+            .thumbnailImageUrl(course.getThumbnailImageUrl())
+            .build();
+    }
+
+}

--- a/src/main/java/com/movte/slate/domain/course/repository/CourseQueryRepository.java
+++ b/src/main/java/com/movte/slate/domain/course/repository/CourseQueryRepository.java
@@ -1,0 +1,9 @@
+package com.movte.slate.domain.course.repository;
+
+import com.movte.slate.domain.course.domain.Course;
+import java.util.Optional;
+
+public interface CourseQueryRepository {
+
+    Optional<Course> selectCourseByIdWithImages(Long id);
+}

--- a/src/main/java/com/movte/slate/domain/course/repository/CourseQueryRepositoryImpl.java
+++ b/src/main/java/com/movte/slate/domain/course/repository/CourseQueryRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.movte.slate.domain.course.repository;
+
+import static com.movte.slate.domain.course.domain.QCourse.course;
+import static com.movte.slate.domain.course.domain.QCourseImage.courseImage;
+
+import com.movte.slate.domain.course.domain.Course;
+import com.movte.slate.domain.course.domain.QCourse;
+import com.movte.slate.domain.course.domain.QCourseImage;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+
+@Component
+@RequiredArgsConstructor
+public class CourseQueryRepositoryImpl implements CourseQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<Course> selectCourseByIdWithImages(Long id) {
+        Course findCourse = queryFactory.select(course)
+            .from(course)
+            .leftJoin(course.courseImages, courseImage)
+            .where(course.id.eq(id))
+            .fetchOne();
+        return Optional.ofNullable(findCourse);
+    }
+}

--- a/src/main/java/com/movte/slate/domain/course/repository/CourseRepository.java
+++ b/src/main/java/com/movte/slate/domain/course/repository/CourseRepository.java
@@ -1,0 +1,9 @@
+package com.movte.slate.domain.course.repository;
+
+import com.movte.slate.domain.course.domain.Course;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CourseRepository extends JpaRepository<Course, Long>, CourseQueryRepository {
+
+
+}

--- a/src/main/java/com/movte/slate/global/exception/NotFoundExceptionCode.java
+++ b/src/main/java/com/movte/slate/global/exception/NotFoundExceptionCode.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum NotFoundExceptionCode {
     NOT_FOUND_ATTRACTION("001", "해당 관광지를 찾을 수 없습니다."),
     NOT_FOUND_MOVIE("002","해당 영화를 찾을 수 없습니다."),
-    NOT_FOUND_SCENE("003","해당 영화 씬을 찾을 수 없습니다");
+    NOT_FOUND_SCENE("003","해당 영화 씬을 찾을 수 없습니다"),
+    NOT_FOUND_COURSE("004","해당 코스를 찾을 수 없습니다.");
     private final String code;
     private final String descriptionMessage;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,10 @@ spring:
   config:
     import:
       - optional:.env.properties
-
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
# 개발사항

- 코스 리스트 조회 구현
- 코스 상세 조회 구현

## 세부사항

### 코스 리스트 조회 구현

- 코스 제목, 부제목, 썸네일 이미지 리턴합니다 
- 썸네일 이미지 -> 텍스트 없는 첫 번째 이미지

### 코스 상세 조회 구현

- 코스 이미지들도 리턴하며 order 순서로 정렬해서 보여줍니다.

## 추가사항

Closes #90