### PR TITLE
Refactor(#96): map api 수정 및 영화 상세 조회 응답값 수정

### DIFF
--- a/src/main/java/com/movte/slate/domain/attraction/application/usecase/AttractionSearchUseCase.java
+++ b/src/main/java/com/movte/slate/domain/attraction/application/usecase/AttractionSearchUseCase.java
@@ -42,13 +42,14 @@ public class AttractionSearchUseCase {
                 .stream().map(MapSearchResponseDto::from)
                 .toList();
             result.addAll(queryResult);
+        } else {
+            List<MapSearchResponseDto> queryResult = sceneRepository.selectSceneByGps(
+                    requestLatitude,
+                    requestLongitude, range)
+                .stream().map(MapSearchResponseDto::from)
+                .toList();
+            result.addAll(queryResult);
         }
-        List<MapSearchResponseDto> queryResult = sceneRepository.selectSceneByGps(
-                requestLatitude,
-                requestLongitude, range)
-            .stream().map(MapSearchResponseDto::from)
-            .toList();
-        result.addAll(queryResult);
         return result;
     }
 

--- a/src/main/java/com/movte/slate/domain/attraction/application/usecase/AttractionSearchUseCase.java
+++ b/src/main/java/com/movte/slate/domain/attraction/application/usecase/AttractionSearchUseCase.java
@@ -30,27 +30,24 @@ public class AttractionSearchUseCase {
     private final SceneRepository sceneRepository;
 
     public List<MapSearchResponseDto> searchMap(MapSearchRequestDto requestDto) {
-        List<MapSearchResponseDto> result = new ArrayList<>();
 
         BigDecimal requestLongitude = new BigDecimal(requestDto.getLongitude());
         BigDecimal requestLatitude = new BigDecimal(requestDto.getLatitude());
         double range = Double.parseDouble(requestDto.getRange().toString());
         if (searchTargetIsAttraction(requestDto.getLocationType())) {
             AttractionType attractionType = requestDto.getLocationType().toAttractionType();
-            List<MapSearchResponseDto> queryResult = attractionRepository.selectAttractionByTypeAndGps(
+
+            return attractionRepository.selectAttractionByTypeAndGps(
                     attractionType, requestLatitude, requestLongitude, range)
                 .stream().map(MapSearchResponseDto::from)
                 .toList();
-            result.addAll(queryResult);
-        } else {
-            List<MapSearchResponseDto> queryResult = sceneRepository.selectSceneByGps(
-                    requestLatitude,
-                    requestLongitude, range)
-                .stream().map(MapSearchResponseDto::from)
-                .toList();
-            result.addAll(queryResult);
         }
-        return result;
+
+        return sceneRepository.selectSceneByGps(
+                requestLatitude,
+                requestLongitude, range)
+            .stream().map(MapSearchResponseDto::from)
+            .toList();
     }
 
     private boolean searchTargetIsAttraction(LocationTypeDto type) {

--- a/src/main/java/com/movte/slate/domain/movie/dto/MovieDetailResponseDto.java
+++ b/src/main/java/com/movte/slate/domain/movie/dto/MovieDetailResponseDto.java
@@ -58,6 +58,10 @@ public class MovieDetailResponseDto {
                 posterUrl = posterOriginUrl.split("\\|")[0];
             }
         }
+        List<SceneImageResponseDto> scenes = null;
+        if (movie.getScenes().size() > 0) {
+            scenes = movie.getScenes().stream().map(SceneImageResponseDto::from).toList();
+        }
 
         return MovieDetailResponseDto.builder()
             .id(movie.getMovieId())
@@ -71,7 +75,7 @@ public class MovieDetailResponseDto {
             .audienceCount(movie.getAudienceCount())
             .plot(movie.getPlot())
             .movieCastList(movieCast)
-            .sceneImages(movie.getScenes().stream().map(SceneImageResponseDto::from).toList())
+            .sceneImages(scenes)
             .build();
     }
 }


### PR DESCRIPTION
# 개발사항

- map api 수정 

- 영화 상세 조회 응답값 수정

## 세부사항

### Map API 수정

- 기존에 관광지 타입인데도 영화 촬영지를 리턴해서 문제가 됨. 
- else 추가했습니다.

###  영화 상세 조회 응답값 수정

-  영화 상세 조회시 씬이 없을때 빈 배열을 줬는데 클라이언트에서 null로 변경해달라고 해서 수정했습니다.

## 추가사항